### PR TITLE
Stop embedding absolute local paths in saved quantization profiles

### DIFF
--- a/profiles/ideogram4_nvfp4_mixed.json
+++ b/profiles/ideogram4_nvfp4_mixed.json
@@ -1,7 +1,6 @@
 {
   "__metadata__": {
     "original_model_name": "ideogram4_nvfp4_mixed",
-    "original_model_path": "E:\\AI\\ComfyUI-Easy-Install\\ComfyUI-Easy-Install\\ComfyUI\\models\\diffusion_models\\ideogram4_nvfp4_mixed.safetensors",
     "timestamp": "2026-07-13T20:40:53.055387",
     "total_layers": 1050,
     "created_by": "Star Model Layers Info"

--- a/profiles/ideogram4_unconditional_nvfp4_mixed.json
+++ b/profiles/ideogram4_unconditional_nvfp4_mixed.json
@@ -1,7 +1,6 @@
 {
   "__metadata__": {
     "original_model_name": "ideogram4_unconditional_nvfp4_mixed",
-    "original_model_path": "E:\\AI\\ComfyUI-Easy-Install\\ComfyUI-Easy-Install\\ComfyUI\\models\\diffusion_models\\ideogram4_unconditional_nvfp4_mixed.safetensors",
     "timestamp": "2026-07-13T20:58:17.499077",
     "total_layers": 1050,
     "created_by": "Star Model Layers Info"

--- a/star_model_layers_info.py
+++ b/star_model_layers_info.py
@@ -224,7 +224,7 @@ class StarModelLayersInfo:
         # Save profile if requested
         profile_file = None
         if save_profile:
-            profile_file = self._save_quantization_profile(layer_data, base_name, input_path)
+            profile_file = self._save_quantization_profile(layer_data, base_name)
         
         # Build status message
         status_lines = [
@@ -393,19 +393,24 @@ class StarModelLayersInfo:
         
         return groups
     
-    def _save_quantization_profile(self, layer_data, model_name, model_path):
+    def _save_quantization_profile(self, layer_data, model_name):
         """Save quantization profile as JSON for use with Model Converter Pro."""
         from datetime import datetime
-        
+
         # Create profiles directory
         profiles_dir = os.path.join(os.path.dirname(__file__), "profiles")
         os.makedirs(profiles_dir, exist_ok=True)
-        
+
         # Build profile structure
+        # NOTE: we intentionally do not store the original model's absolute
+        # filesystem path here. Profiles are meant to be shared/reused across
+        # machines, and an absolute path can leak local usernames or
+        # directory layout (and is also served back verbatim by the
+        # /starnodes/profile/{name} tooltip API). original_model_name already
+        # carries the useful, shareable part (the model's filename).
         profile = {
             "__metadata__": {
                 "original_model_name": model_name,
-                "original_model_path": model_path,
                 "timestamp": datetime.now().isoformat(),
                 "total_layers": len(layer_data),
                 "created_by": "Star Model Layers Info"


### PR DESCRIPTION
Hiya,

Really ambitious project and I appreciate it, ty.  Here's a small contribution for your consideration.

## What this does and why

This patch stops the node from writing a local absolute file path into quantization profile files that are meant to be shared or reused across machines. Plenty of Comfy users have Comfy installed on their desktop... the current arrangement would potentially have every single model they processed w/ your tool fingerprinted with something like "c:\users\Snickel Fritz\Desktop\ComfyUI\models\checkpoints\furries_nsfw.safetensors" or some such.  

---

### Details

`_save_quantization_profile()` recorded the source model's full absolute path under `__metadata__.original_model_path`. `original_model_name` (the model's filename) already carries the useful, shareable part and is the only field actually consumed elsewhere (status messages, the tooltip UI), so `original_model_path` is dropped entirely rather than replaced with something else.

### Testing

Syntax-checked and diff-reviewed; this only removes a field that was never read back by any other part of the codebase.

Please lmk if you have any questions.

Best regards,
FNG