### PR TITLE
Fix path traversal in profile API and model output naming

### DIFF
--- a/api_routes.py
+++ b/api_routes.py
@@ -13,8 +13,19 @@ async def get_profile_metadata(request):
     """Return profile metadata for tooltip display."""
     try:
         profile_name = request.match_info["profile_name"]
-        profile_path = os.path.join(PROFILES_DIR, profile_name)
-        
+
+        # profile_name comes straight from the URL. Reject anything that isn't
+        # a plain "*.json" filename so a crafted (possibly percent-encoded)
+        # value like "../../secrets.json" can't escape PROFILES_DIR.
+        safe_name = os.path.basename(profile_name)
+        if safe_name != profile_name or not safe_name.endswith(".json"):
+            return web.json_response({"error": "Invalid profile name"}, status=400)
+
+        profiles_root = os.path.realpath(PROFILES_DIR)
+        profile_path = os.path.realpath(os.path.join(profiles_root, safe_name))
+        if os.path.commonpath([profile_path, profiles_root]) != profiles_root:
+            return web.json_response({"error": "Invalid profile name"}, status=400)
+
         if not os.path.exists(profile_path):
             return web.json_response({"error": "Profile not found"}, status=404)
         

--- a/star_model_converter_pro.py
+++ b/star_model_converter_pro.py
@@ -269,10 +269,19 @@ class StarUltimateModelConverterPro:
         # Determine output name
         if output_name and output_name.strip():
             base_name = output_name.strip()
+            # output_name is a free-text field. Strip it down to a bare
+            # filename so it can't be used to write outside output_dir
+            # (e.g. "../../evil" or an absolute path like "C:\\evil").
+            safe_base_name = os.path.basename(base_name)
+            if not safe_base_name or safe_base_name != base_name:
+                raise ValueError(
+                    "output_name must be a plain filename without path separators or a drive letter."
+                )
+            base_name = safe_base_name
         else:
             model_base = os.path.splitext(model_name)[0]
             base_name = f"{model_base}_{target_quant_format.lower()}_pro"
-        
+
         if not base_name.endswith(".safetensors"):
             base_name += ".safetensors"
         
@@ -288,7 +297,14 @@ class StarUltimateModelConverterPro:
         # Save converted model
         output_dir = folder_paths.get_folder_paths("diffusion_models")[0]
         output_path = os.path.join(output_dir, base_name)
-        
+
+        # Defense in depth: confirm the resolved path still lands inside
+        # output_dir before writing anything to disk.
+        output_dir_real = os.path.realpath(output_dir)
+        output_path_real = os.path.realpath(output_path)
+        if os.path.commonpath([output_path_real, output_dir_real]) != output_dir_real:
+            raise ValueError("Resolved output path escapes the diffusion_models folder.")
+
         print(f"💾 Saving converted model to: {output_path}")
         safetensors.torch.save_file(new_sd, output_path, metadata=final_metadata)
         

--- a/starnodes_aio_saver.py
+++ b/starnodes_aio_saver.py
@@ -57,7 +57,26 @@ class StarnodesAIOSaver:
         start_time = time.time()
 
         ckpt_dir = folder_paths.get_folder_paths("checkpoints")[0]
+
+        # output_name is free text. Strip it down to a bare filename so it
+        # can't be used to write outside ckpt_dir (e.g. "../../evil" or an
+        # absolute path like "C:\\evil").
+        stripped_name = (output_name or "").strip()
+        safe_output_name = os.path.basename(stripped_name)
+        if not safe_output_name or safe_output_name != stripped_name:
+            raise ValueError(
+                "output_name must be a plain filename without path separators or a drive letter."
+            )
+        output_name = safe_output_name
+
         out_path = os.path.join(ckpt_dir, f"{output_name}.safetensors")
+
+        # Defense in depth: confirm the resolved path still lands inside
+        # ckpt_dir before writing anything to disk.
+        ckpt_dir_real = os.path.realpath(ckpt_dir)
+        out_path_real = os.path.realpath(out_path)
+        if os.path.commonpath([out_path_real, ckpt_dir_real]) != ckpt_dir_real:
+            raise ValueError("Resolved output path escapes the checkpoints folder.")
 
         components = [
             ("Model", model_name, "diffusion_models", model_prefix),


### PR DESCRIPTION
Hiya,

Really ambitious project and I appreciate it, ty.  Here's a small contribution for your consideration.

## What this does and why

This closes two path traversal issues: one lets a request to the profile-tooltip API read arbitrary files on disk instead of just files in this node's `profiles/` folder, and the other lets a workflow's output filename escape the intended `models/` folder and write a file somewhere else on the system. Both are fixed by rejecting any input that isn't a plain filename before it's used to build a filesystem path.  This is worth fixing because it could possibly lead to someone sharing poisoned workflows that could lead to system compromise or DoS.

---

### Details

**`api_routes.py`** — the `/starnodes/profile/{profile_name}` endpoint joined the raw URL segment into `PROFILES_DIR` with no containment check. A crafted (possibly percent-encoded) value like `..%2f..%2fsecret.json` could escape the profiles folder and read any JSON file reachable by the server. Now rejects any value that isn't a bare `*.json` filename and double-checks the resolved path stays under `PROFILES_DIR`.

**`star_model_converter_pro.py` / `starnodes_aio_saver.py`** — the `output_name` free-text widget was concatenated straight into the save path via `os.path.join(output_dir, base_name)`. Since `os.path.join` discards the first argument when the second is absolute, an `output_name` like `C:\evil` or `../../evil` let a workflow write the converted model completely outside the intended `diffusion_models`/`checkpoints` folder. Both nodes now strip `output_name` to a bare filename (rejecting traversal/absolute values) and verify the resolved path still lands inside the target folder before saving.

### Testing

Syntax-checked and diff-reviewed; no functional test harness changes needed since this only tightens input validation on paths that were already expected to be plain filenames.

Please lmk if you have any questions.

Best regards,
FNG