### PR TITLE
Feature/streaming load and fp8 preserve

### DIFF
--- a/star_ultimate_converter.py
+++ b/star_ultimate_converter.py
@@ -404,7 +404,149 @@ def build_output_path(out_dir, base_name, target_format):
     return os.path.join(out_dir, f"{stem}-{target_format}.safetensors")
 
 
+class LazyStateDict:
+    """A dict-like state-dict view backed by one or more safetensors files, reading
+    each tensor from disk lazily (one at a time, on access) instead of loading the
+    whole checkpoint into RAM up front.
+
+    This is what makes converting large checkpoints possible on memory-constrained
+    hosts: loading the entire file into RAM before any per-tensor decision is
+    made, then upcasting every fp8 tensor to bf16 in a single pass, can drive
+    peak memory to several times the checkpoint's own file size. With this
+    class, only whichever tensor is currently being processed is ever resident.
+
+    Supports the subset of dict behavior the rest of this module needs:
+    __contains__, __getitem__, __setitem__, __delitem__, pop, __iter__, keys,
+    values, items, __len__. Tensors that get overwritten in place -- e.g.
+    dequantize_input() synthesizes combined weight*scale tensors and removes
+    consumed scale/marker keys -- live in a small in-memory overlay, since the
+    backing files themselves are read-only.
+
+    If `key_prefix` is given, only keys starting with it are exposed (with the
+    prefix stripped), which replaces the old pattern of eagerly loading an entire
+    AIO checkpoint just to throw away everything outside
+    "model.diffusion_model.".
+
+    Duplicate keys across shards: the last shard that defines a key wins, matching
+    the previous `sd.update(part)` behavior.
+    """
+
+    def __init__(self, files, key_prefix=None):
+        self._files = list(files)
+        self._prefix = key_prefix or ""
+        self._handles = [safetensors.safe_open(fp, framework="pt") for fp in self._files]
+
+        self._key_to_handle = {}
+        for idx, handle in enumerate(self._handles):
+            for raw_key in handle.keys():
+                if not raw_key.startswith(self._prefix):
+                    continue
+
+                key = raw_key[len(self._prefix):]
+
+                if key in self._key_to_handle:
+                    print(f"⚠️ Duplicate key '{key}' in {os.path.basename(self._files[idx])}, overwriting")
+
+                self._key_to_handle[key] = (idx, raw_key)
+
+        self._overlay = {}
+        self._deleted = set()
+        self._metadata = self._handles[0].metadata() if self._handles else None
+
+    def metadata(self):
+        return self._metadata
+
+    def close(self):
+        for handle in self._handles:
+            exit_fn = getattr(handle, "__exit__", None)
+            if exit_fn is not None:
+                try:
+                    exit_fn(None, None, None)
+                except Exception:
+                    pass
+
+        self._handles = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+    def __contains__(self, key):
+        return key not in self._deleted and (key in self._overlay or key in self._key_to_handle)
+
+    def __getitem__(self, key):
+        if key in self._deleted:
+            raise KeyError(key)
+
+        if key in self._overlay:
+            return self._overlay[key]
+
+        if key in self._key_to_handle:
+            idx, raw_key = self._key_to_handle[key]
+            return self._handles[idx].get_tensor(raw_key)
+
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        self._overlay[key] = value
+        self._deleted.discard(key)
+
+    def __delitem__(self, key):
+        if key not in self:
+            raise KeyError(key)
+
+        self._overlay.pop(key, None)
+        self._deleted.add(key)
+
+    def pop(self, key, *default):
+        if key in self:
+            value = self[key]
+            del self[key]
+            return value
+
+        if default:
+            return default[0]
+
+        raise KeyError(key)
+
+    def __iter__(self):
+        seen = set()
+
+        for key in self._overlay:
+            if key not in self._deleted:
+                seen.add(key)
+                yield key
+
+        for key in self._key_to_handle:
+            if key not in self._deleted and key not in seen:
+                yield key
+
+    def keys(self):
+        return list(iter(self))
+
+    def values(self):
+        for key in self:
+            yield self[key]
+
+    def items(self):
+        for key in self:
+            yield key, self[key]
+
+    def __len__(self):
+        return sum(1 for _ in self)
+
+
 def load_input(files):
+    if all(fp.endswith(".safetensors") for fp in files):
+        sd = LazyStateDict(files)
+        return sd, sd.metadata()
+
+    # Legacy / non-safetensors input (e.g. a pickled .ckpt VAE): can't be read
+    # lazily, so fall back to the previous eager loading behavior.
+    print("⚠️ Non-safetensors input detected; loading eagerly (streaming load requires .safetensors).")
+
     sd = {}
 
     for i, fp in enumerate(files):
@@ -419,8 +561,11 @@ def load_input(files):
 
         sd.update(part)
 
-    with safetensors.safe_open(files[0], framework="pt") as f:
-        orig_meta = f.metadata()
+    orig_meta = None
+
+    if files[0].endswith(".safetensors"):
+        with safetensors.safe_open(files[0], framework="pt") as f:
+            orig_meta = f.metadata()
 
     return sd, orig_meta
 
@@ -780,37 +925,67 @@ class StarUltimateModelConverter:
 
             ckpt_path = folder_paths.get_full_path("checkpoints", checkpoint)
             base_name = os.path.splitext(os.path.basename(ckpt_path))[0]
-            orig_meta = None
+            files = [ckpt_path]
 
             if ckpt_path.endswith(".safetensors"):
-                with safetensors.safe_open(ckpt_path, framework="pt") as f:
-                    orig_meta = f.metadata()
+                # Stream the checkpoint instead of loading it whole: for AIO mode
+                # this is the entire multi-GB file, and for Checkpoint mode the old
+                # code loaded the *whole* AIO file (unet + CLIP + VAE) just to keep
+                # the unet-prefixed keys and throw the rest away.
+                if mode == "Checkpoint":
+                    print(f"✂️ Extracting diffusion model from AIO checkpoint: {checkpoint}")
 
-            full_sd = comfy.utils.load_torch_file(ckpt_path, safe_load=True)
+                    sd = LazyStateDict(files, key_prefix=AIO_MODEL_PREFIX)
 
-            if mode == "Checkpoint":
-                print(f"✂️ Extracting diffusion model from AIO checkpoint: {checkpoint}")
+                    if len(sd) == 0:
+                        raise ValueError(
+                            f"No '{AIO_MODEL_PREFIX}' keys found in {os.path.basename(ckpt_path)}. "
+                            "Is this an all-in-one checkpoint?"
+                        )
 
-                sd = {
-                    k[len(AIO_MODEL_PREFIX):]: v
-                    for k, v in full_sd.items()
-                    if k.startswith(AIO_MODEL_PREFIX)
-                }
+                    orig_meta = sd.metadata()
+                    input_bytes = sum(v.numel() * v.element_size() for v in sd.values())
+                    output_path = build_output_path(diffusion_models_dir(), base_name, target_format)
 
-                input_bytes = sum(v.numel() * v.element_size() for v in sd.values())
-                output_path = build_output_path(diffusion_models_dir(), base_name, target_format)
-                files = [ckpt_path]
+                else:
+                    print(f"🔄 AIO Mode: Processing entire checkpoint intact: {checkpoint}")
 
-                del full_sd
+                    sd = LazyStateDict(files)
+                    orig_meta = sd.metadata()
+                    input_bytes = os.path.getsize(ckpt_path)
+                    checkpoints_dir = folder_paths.get_folder_paths("checkpoints")[0]
+                    output_path = build_output_path(checkpoints_dir, f"{base_name}_AIO", target_format)
 
             else:
-                print(f"🔄 AIO Mode: Processing entire checkpoint intact: {checkpoint}")
+                # Legacy / non-safetensors checkpoint (e.g. a pickled .ckpt): can't
+                # be read lazily, so fall back to the previous eager loading
+                # behavior.
+                print("⚠️ Non-safetensors checkpoint detected; loading eagerly (streaming load requires .safetensors).")
 
-                sd = full_sd
-                input_bytes = os.path.getsize(ckpt_path)
-                checkpoints_dir = folder_paths.get_folder_paths("checkpoints")[0]
-                output_path = build_output_path(checkpoints_dir, f"{base_name}_AIO", target_format)
-                files = [ckpt_path]
+                orig_meta = None
+                full_sd = comfy.utils.load_torch_file(ckpt_path, safe_load=True)
+
+                if mode == "Checkpoint":
+                    print(f"✂️ Extracting diffusion model from AIO checkpoint: {checkpoint}")
+
+                    sd = {
+                        k[len(AIO_MODEL_PREFIX):]: v
+                        for k, v in full_sd.items()
+                        if k.startswith(AIO_MODEL_PREFIX)
+                    }
+
+                    input_bytes = sum(v.numel() * v.element_size() for v in sd.values())
+                    output_path = build_output_path(diffusion_models_dir(), base_name, target_format)
+
+                    del full_sd
+
+                else:
+                    print(f"🔄 AIO Mode: Processing entire checkpoint intact: {checkpoint}")
+
+                    sd = full_sd
+                    input_bytes = os.path.getsize(ckpt_path)
+                    checkpoints_dir = folder_paths.get_folder_paths("checkpoints")[0]
+                    output_path = build_output_path(checkpoints_dir, f"{base_name}_AIO", target_format)
 
         else:
             files, out_dir, base_name = resolve_input(
@@ -1383,6 +1558,12 @@ class StarUltimateModelConverter:
                     else:
                         new_sd[k] = v
                         counts["kept"] += 1
+
+        # Done reading from the source file(s) -- release the safetensors handles
+        # (matters most on Windows, where a lingering open mmap can block later
+        # operations on the same file).
+        if hasattr(sd, "close"):
+            sd.close()
 
         final_metadata = OrderedDict()
 

--- a/star_ultimate_converter.py
+++ b/star_ultimate_converter.py
@@ -170,6 +170,28 @@ def blacklisted_dtype(k: str, keep_fp32, keep_fp16) -> torch.dtype:
     return torch.bfloat16
 
 
+def preserve_dtype(v, k=None, keep_fp32=None, keep_fp16=None):
+    """For tensors that are being kept as-is (not quantized further): if the tensor
+    is already native fp8, leave it untouched instead of upcasting to bf16.
+    Upcasting fp8 -> bf16 cannot recover precision the source already discarded, so
+    doing it unconditionally just doubles the storage of every already-fp8 tensor
+    (biases, norms, blacklisted layers, quantization fallbacks, ...) for zero
+    numerical benefit -- this matters a lot for checkpoints that ship natively in
+    fp8 (e.g. some Qwen-Image-Edit merges). Non-fp8 floating tensors still go
+    through the normal blacklisted-dtype policy (or plain bf16 if no key is given).
+    """
+    if not v.dtype.is_floating_point:
+        return v
+
+    if v.dtype in FP8_DTYPES:
+        return v
+
+    if k is not None:
+        return v.to(dtype=blacklisted_dtype(k, keep_fp32 or [], keep_fp16 or []))
+
+    return v.to(torch.bfloat16)
+
+
 def resolve_input(mode, diffusion_model, checkpoint, text_encoder, custom_path, vae="None"):
     """Resolve the target path based on the selected mode."""
 
@@ -587,10 +609,14 @@ def dequantize_input(sd, metadata):
             elif v.dtype == torch.int8:
                 raise ValueError(f"int8 weight '{k}' has no '{k}_scale' tensor, cannot dequantize.")
 
-    for k, v in sd.items():
-        if v.dtype in FP8_DTYPES:
-            sd[k] = v.to(torch.bfloat16)
-
+    # NOTE: there used to be a final "upcast every remaining fp8 tensor to bf16"
+    # pass here. It was removed: by this point any fp8 tensor that still needed
+    # dequantizing (had a matching *_scale companion) has already been converted
+    # above, so anything still fp8 here is either genuinely native fp8 with no
+    # scale to apply, or about to be blacklisted/kept as-is by the caller -- in
+    # both cases bf16 can't recover precision that's already gone, so upcasting
+    # it here only doubled the file size of every such tensor for no benefit.
+    # See preserve_dtype(), used by the caller's keep-as-is branches instead.
     return sd
 
 
@@ -879,7 +905,7 @@ class StarUltimateModelConverter:
 
                     else:
                         if v.dtype.is_floating_point:
-                            new_sd[k] = v.to(dtype=torch.bfloat16)
+                            new_sd[k] = preserve_dtype(v)
                             counts["kept bf16 (VAE/Misc)"] += 1
                         else:
                             new_sd[k] = v
@@ -923,7 +949,7 @@ class StarUltimateModelConverter:
 
                 if any(name in k for name in active_blacklist):
                     if v.dtype.is_floating_point:
-                        new_sd[k] = v.to(dtype=blacklisted_dtype(k, active_keep_fp32, active_keep_fp16))
+                        new_sd[k] = preserve_dtype(v, k, active_keep_fp32, active_keep_fp16)
                         counts["kept bf16/f16/f32"] += 1
                     else:
                         new_sd[k] = v
@@ -961,7 +987,7 @@ class StarUltimateModelConverter:
                             print(f"⚠️ Forced INT8 failed for {k}: {e}")
 
                             if v.dtype.is_floating_point:
-                                new_sd[k] = v.to(dtype=torch.bfloat16)
+                                new_sd[k] = preserve_dtype(v)
                                 counts["kept bf16"] += 1
                             else:
                                 new_sd[k] = v
@@ -1003,7 +1029,7 @@ class StarUltimateModelConverter:
                             print(f"⚠️ OVERRIDE int4_convrot failed for {k}: {e}")
 
                             if v.dtype.is_floating_point:
-                                new_sd[k] = v.to(dtype=torch.bfloat16)
+                                new_sd[k] = preserve_dtype(v)
                                 counts["kept bf16"] += 1
                             else:
                                 new_sd[k] = v
@@ -1046,7 +1072,7 @@ class StarUltimateModelConverter:
                             print(f"⚠️ OVERRIDE int8_convrot failed for {k}: {e}")
 
                             if v.dtype.is_floating_point:
-                                new_sd[k] = v.to(dtype=torch.bfloat16)
+                                new_sd[k] = preserve_dtype(v)
                                 counts["kept bf16"] += 1
                             else:
                                 new_sd[k] = v
@@ -1129,7 +1155,7 @@ class StarUltimateModelConverter:
                             print(f"⚠️ SVDQuant failed for {k}: {e}")
 
                             if v.dtype.is_floating_point:
-                                new_sd[k] = v.to(dtype=torch.bfloat16)
+                                new_sd[k] = preserve_dtype(v)
                                 counts["kept bf16"] += 1
                             else:
                                 new_sd[k] = v
@@ -1144,12 +1170,12 @@ class StarUltimateModelConverter:
                         blk_idx = block_index_from_key(k)
 
                         if "attn.out_proj" in k:
-                            new_sd[k] = v.to(dtype=torch.bfloat16)
+                            new_sd[k] = preserve_dtype(v)
                             counts["kept bf16 (out_proj)"] += 1
                             continue
 
                         if blk_idx in MINIMAX_H3_BOUNDARY_BLOCKS:
-                            new_sd[k] = v.to(dtype=torch.bfloat16)
+                            new_sd[k] = preserve_dtype(v)
                             counts["kept bf16 (boundary block)"] += 1
                             continue
 
@@ -1184,7 +1210,7 @@ class StarUltimateModelConverter:
                             except Exception as e:
                                 print(f"⚠️ NATIVE_MIX qkv_proj failed for {k}: {e}")
 
-                                new_sd[k] = v.to(dtype=torch.bfloat16)
+                                new_sd[k] = preserve_dtype(v)
                                 counts["kept bf16"] += 1
 
                                 if device == "cuda":
@@ -1216,7 +1242,7 @@ class StarUltimateModelConverter:
                             except Exception as e:
                                 print(f"⚠️ NATIVE_MIX mlp failed for {k}: {e}")
 
-                                new_sd[k] = v.to(dtype=torch.bfloat16)
+                                new_sd[k] = preserve_dtype(v)
                                 counts["kept bf16"] += 1
 
                                 if device == "cuda":
@@ -1224,7 +1250,7 @@ class StarUltimateModelConverter:
 
                             continue
 
-                        new_sd[k] = v.to(dtype=torch.bfloat16)
+                        new_sd[k] = preserve_dtype(v)
                         counts["kept bf16 (native_mix other)"] += 1
                         continue
 
@@ -1255,7 +1281,7 @@ class StarUltimateModelConverter:
                             print(f"⚠️ W4A8 ConvRot failed for {k}: {e}")
 
                             if v.dtype.is_floating_point:
-                                new_sd[k] = v.to(dtype=torch.bfloat16)
+                                new_sd[k] = preserve_dtype(v)
                                 counts["w4a8_failed_bf16"] += 1
                             else:
                                 new_sd[k] = v
@@ -1341,7 +1367,7 @@ class StarUltimateModelConverter:
                         print(f"⚠️ Quantization failed for {k}: {e}")
 
                         if v.dtype.is_floating_point:
-                            new_sd[k] = v.to(dtype=torch.bfloat16)
+                            new_sd[k] = preserve_dtype(v)
                             counts["kept bf16"] += 1
                         else:
                             new_sd[k] = v
@@ -1352,7 +1378,7 @@ class StarUltimateModelConverter:
 
                 else:
                     if v.dtype.is_floating_point:
-                        new_sd[k] = v.to(dtype=torch.bfloat16)
+                        new_sd[k] = preserve_dtype(v)
                         counts["kept bf16"] += 1
                     else:
                         new_sd[k] = v

--- a/star_ultimate_converter.py
+++ b/star_ultimate_converter.py
@@ -119,11 +119,11 @@ DTYPE_NAMES = {
 }
 
 
-def _make_memory_trimmer():
+def _make_cpu_memory_trimmer():
     """Best-effort, cross-platform function that asks the OS to reclaim this
-    process's freed-but-retained memory. Never raises -- any failure (wrong
-    platform, missing library, permission issue) falls back to a no-op, so
-    this can never become a new way for a conversion to fail.
+    process's freed-but-retained CPU memory. Never raises -- any failure
+    (wrong platform, missing library, permission issue) falls back to a
+    no-op, so this can never become a new way for a conversion to fail.
 
     General-purpose C allocators (glibc's arena on Linux, the Windows heap
     manager) tend to retain freed blocks for possible reuse rather than
@@ -175,6 +175,32 @@ def _make_memory_trimmer():
         pass
 
     return _noop
+
+
+def _make_memory_trimmer():
+    """Combines the CPU trimmer above with PyTorch's own torch.cuda.empty_cache().
+
+    CUDA's caching allocator can exhibit the same retention pattern as the
+    OS heap above, just on GPU memory: many sequential, differently-sized
+    quantization allocations can accumulate reserved memory that's never
+    returned to the driver, which is more pronounced for formats whose
+    quantization path allocates a wider variety of tensor shapes and sizes
+    per layer (e.g. block-scaled formats like NVFP4, compared to a uniform
+    per-tensor scale like fp8). Unlike the CPU case, PyTorch already exposes
+    the fix as a first-class, always-safe API, so no platform-specific code
+    is needed here.
+    """
+    cpu_trim = _make_cpu_memory_trimmer()
+
+    def _trim():
+        cpu_trim()
+        try:
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    return _trim
 
 
 trim_process_memory = _make_memory_trimmer()
@@ -969,6 +995,7 @@ class StarUltimateModelConverter:
     CATEGORY = "⭐StarNodes/Model Tools"
     OUTPUT_NODE = True
 
+    @torch.no_grad()
     def convert(
         self,
         mode,
@@ -983,6 +1010,8 @@ class StarUltimateModelConverter:
         svdquant_rank=64,
         svdquant_refine_iters=10,
     ):
+        # This is pure weight transformation, never training, so gradient
+        # tracking should never be active here.
         configs = load_model_configs()
 
         (
@@ -1662,6 +1691,9 @@ class StarUltimateModelConverter:
                         quant_map["layers"][base_k_meta] = layer_conf
                         counts[target_format] += 1
 
+                        if device == "cuda":
+                            del v_tensor, v_tensor_ready
+
                     except Exception as e:
                         print(f"⚠️ Quantization failed for {k}: {e}")
 
@@ -1672,8 +1704,8 @@ class StarUltimateModelConverter:
                             new_sd[k] = v
                             counts["kept"] += 1
 
-                    if device == "cuda":
-                        del v_tensor
+                        if device == "cuda":
+                            del v_tensor
 
                 else:
                     if v.dtype.is_floating_point:

--- a/star_ultimate_converter.py
+++ b/star_ultimate_converter.py
@@ -1,9 +1,11 @@
 import os
 import re
+import sys
 import json
 import time
 import glob
 import math
+import ctypes
 import inspect
 
 import torch
@@ -115,6 +117,74 @@ DTYPE_NAMES = {
     torch.float8_e5m2: "fp8_e5m2",
     torch.int8: "int8",
 }
+
+
+def _make_memory_trimmer():
+    """Best-effort, cross-platform function that asks the OS to reclaim this
+    process's freed-but-retained memory. Never raises -- any failure (wrong
+    platform, missing library, permission issue) falls back to a no-op, so
+    this can never become a new way for a conversion to fail.
+
+    General-purpose C allocators (glibc's arena on Linux, the Windows heap
+    manager) tend to retain freed blocks for possible reuse rather than
+    returning pages to the OS, particularly under many differently-sized
+    allocate/free cycles -- the pattern produced by dequantizing scale-linked
+    fp8 tensors one at a time (see LazyStateDict/dequantize_input). Left
+    unchecked, a process's resident memory can grow well beyond what any
+    single live tensor requires and never come back down, even though
+    nothing is leaked at the Python level. Periodically nudging the OS to
+    reclaim what's actually unused keeps peak memory close to what the
+    conversion genuinely needs.
+    """
+    if sys.platform == "win32":
+        try:
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            psapi = ctypes.WinDLL("psapi", use_last_error=True)
+            kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+            psapi.EmptyWorkingSet.argtypes = [ctypes.c_void_p]
+            psapi.EmptyWorkingSet.restype = ctypes.c_bool
+            handle = kernel32.GetCurrentProcess()
+
+            def _trim():
+                try:
+                    psapi.EmptyWorkingSet(handle)
+                except Exception:
+                    pass
+
+            return _trim
+        except Exception:
+            pass
+
+    elif sys.platform.startswith("linux"):
+        try:
+            libc = ctypes.CDLL("libc.so.6")
+            libc.malloc_trim.argtypes = [ctypes.c_size_t]
+            libc.malloc_trim.restype = ctypes.c_int
+
+            def _trim():
+                try:
+                    libc.malloc_trim(0)
+                except Exception:
+                    pass
+
+            return _trim
+        except Exception:
+            pass
+
+    def _noop():
+        pass
+
+    return _noop
+
+
+trim_process_memory = _make_memory_trimmer()
+
+# Call trim_process_memory() roughly this often (in tensors processed) during
+# the main conversion loop. Frequent enough to keep peak RSS down on
+# scale-heavy fp8 checkpoints; infrequent enough that the trim call's own
+# (small, OS-level) overhead stays negligible against real per-tensor
+# GPU/CPU quantization work.
+MEMORY_TRIM_INTERVAL = 50
 
 
 def detect_input_format(sd, metadata):
@@ -422,6 +492,16 @@ class LazyStateDict:
     consumed scale/marker keys -- live in a small in-memory overlay, since the
     backing files themselves are read-only.
 
+    Scale-linked dequantization (a fp8/int8 weight combined with its `_scale`
+    companion into a bf16 tensor) is deferred rather than eager: set_scale_pending()
+    just records the tiny scale tensor, and the actual `raw.float() * scale.float()
+    -> bf16` multiply happens the first time the key is read. This matters for
+    checkpoints that are mostly *properly-scaled* fp8 (as opposed to bare native
+    fp8 with nothing to dequantize) -- computing all of them eagerly, before the
+    conversion loop starts consuming them one at a time, would materialize the
+    *entire* dequantized (bf16, so ~2x the fp8 source) checkpoint in RAM at once,
+    reintroducing the same shape of peak-memory problem this class exists to avoid.
+
     If `key_prefix` is given, only keys starting with it are exposed (with the
     prefix stripped), which replaces the old pattern of eagerly loading an entire
     AIO checkpoint just to throw away everything outside
@@ -451,10 +531,24 @@ class LazyStateDict:
 
         self._overlay = {}
         self._deleted = set()
+        self._pending_scale = {}
         self._metadata = self._handles[0].metadata() if self._handles else None
 
     def metadata(self):
         return self._metadata
+
+    def set_scale_pending(self, key, scale):
+        """Record that `key`'s value is its raw backing tensor times `scale`,
+        upcast to bf16 -- computed lazily the next time `key` is read, not here.
+        `key` must currently resolve to a real (not deleted) entry."""
+        if key not in self:
+            raise KeyError(key)
+
+        self._pending_scale[key] = scale
+
+    def _read_backing(self, key):
+        idx, raw_key = self._key_to_handle[key]
+        return self._handles[idx].get_tensor(raw_key)
 
     def close(self):
         for handle in self._handles:
@@ -483,14 +577,19 @@ class LazyStateDict:
         if key in self._overlay:
             return self._overlay[key]
 
+        if key in self._pending_scale:
+            raw = self._read_backing(key)
+            scale = self._pending_scale[key]
+            return (raw.to(torch.float32) * scale.to(torch.float32)).to(torch.bfloat16)
+
         if key in self._key_to_handle:
-            idx, raw_key = self._key_to_handle[key]
-            return self._handles[idx].get_tensor(raw_key)
+            return self._read_backing(key)
 
         raise KeyError(key)
 
     def __setitem__(self, key, value):
         self._overlay[key] = value
+        self._pending_scale.pop(key, None)
         self._deleted.discard(key)
 
     def __delitem__(self, key):
@@ -498,6 +597,7 @@ class LazyStateDict:
             raise KeyError(key)
 
         self._overlay.pop(key, None)
+        self._pending_scale.pop(key, None)
         self._deleted.add(key)
 
     def pop(self, key, *default):
@@ -727,6 +827,20 @@ def dequantize_input(sd, metadata):
                 "Use a higher precision source model."
             )
 
+    # Combining a raw weight with its scale into a dequantized bf16 tensor is
+    # deferred (via set_scale_pending) rather than computed here, when the state
+    # dict supports it (LazyStateDict does; the legacy eager-dict fallback from
+    # load_input()/the AIO block does not, since it's already fully materialized
+    # anyway). Doing this eagerly for every scale-linked tensor in one pass -- as
+    # opposed to one at a time, when the conversion loop actually consumes each
+    # key -- would materialize the *entire* dequantized checkpoint in RAM at once
+    # for a checkpoint that's mostly properly-scaled fp8, which is exactly the
+    # kind of peak-memory blowup this module's streaming design exists to avoid.
+    set_pending = getattr(sd, "set_scale_pending", None)
+
+    def _dequantize_now(key, scale):
+        sd[key] = (sd[key].to(torch.float32) * scale.to(torch.float32)).to(torch.bfloat16)
+
     if "scaled_fp8" in sd:
         sd.pop("scaled_fp8")
 
@@ -735,7 +849,10 @@ def dequantize_input(sd, metadata):
             wk = k[: -len(".scale_weight")] + ".weight"
 
             if wk in sd:
-                sd[wk] = (sd[wk].to(torch.float32) * scale.to(torch.float32)).to(torch.bfloat16)
+                if set_pending is not None:
+                    set_pending(wk, scale)
+                else:
+                    _dequantize_now(wk, scale)
 
         for k in [k for k in sd if k.endswith(".scale_input")]:
             sd.pop(k)
@@ -750,18 +867,19 @@ def dequantize_input(sd, metadata):
             scale = sd.pop(k + "_scale", None)
 
             if scale is not None:
-                sd[k] = (v.to(torch.float32) * scale.to(torch.float32)).to(torch.bfloat16)
+                if set_pending is not None:
+                    set_pending(k, scale)
+                else:
+                    _dequantize_now(k, scale)
             elif v.dtype == torch.int8:
                 raise ValueError(f"int8 weight '{k}' has no '{k}_scale' tensor, cannot dequantize.")
 
-    # NOTE: there used to be a final "upcast every remaining fp8 tensor to bf16"
-    # pass here. It was removed: by this point any fp8 tensor that still needed
-    # dequantizing (had a matching *_scale companion) has already been converted
-    # above, so anything still fp8 here is either genuinely native fp8 with no
-    # scale to apply, or about to be blacklisted/kept as-is by the caller -- in
-    # both cases bf16 can't recover precision that's already gone, so upcasting
-    # it here only doubled the file size of every such tensor for no benefit.
-    # See preserve_dtype(), used by the caller's keep-as-is branches instead.
+    # Any fp8 tensor still present at this point either had a matching *_scale
+    # companion and was already converted above, or is genuinely native fp8 with
+    # nothing to dequantize and will be blacklisted or kept as-is by the caller.
+    # In neither case does upcasting it to bf16 recover any precision -- it would
+    # only double the storage of every such tensor for no benefit. See
+    # preserve_dtype(), used by the caller's keep-as-is branches instead.
     return sd
 
 
@@ -1034,6 +1152,9 @@ class StarUltimateModelConverter:
             for i, (k, v) in enumerate(sd.items()):
                 pbar.update_absolute(i + 1)
 
+                if (i + 1) % MEMORY_TRIM_INTERVAL == 0:
+                    trim_process_memory()
+
                 if v.dtype.is_floating_point:
                     new_sd[k] = v.to(target_dtype)
                     counts[target_format] += 1
@@ -1044,6 +1165,9 @@ class StarUltimateModelConverter:
         else:
             for i, (k, v) in enumerate(sd.items()):
                 pbar.update_absolute(i + 1)
+
+                if (i + 1) % MEMORY_TRIM_INTERVAL == 0:
+                    trim_process_memory()
 
                 if mode == "AIO":
                     if k.startswith(AIO_MODEL_PREFIX):


### PR DESCRIPTION
Hiya,

Really ambitious project and I appreciate it, ty.  Here's a small contribution for your consideration.

## What this does and why

This fixes out-of-memory crashes when converting models that are large relative to system RAM.  Previously, some models required roughly 2-3x their own file size in free RAM and could silently OOM-kill the process on memory-constrained machines. After this change, converting the same checkpoints uses only a small fraction of that.

There was also an issue when quantizing input models that already had layers in dtypes below what you blacklist.  For example, if someone attempted to quantize a naive fp8 checkpoint down to int4 (some models like ID4 are only distributed at max fp8 or someone might be hurting for storage space), the fp8 would be upcast to f16 but then retained at that size because of the blacklist.  So you end up with a file that is potentially larger than what you began with!  This patch addresses that by skipping the upcast entirely in such cases where possible.  

Validated on real hardware against real checkpoints: a 33GB checkpoint that previously peaked around 48GB of RAM now peaks around 19-25GB depending on target format and a 20GB checkpoint that used to take 195 seconds and grow the output file now takes 50 seconds and keeps the output the same size it should be.  And converting between slightly different flavors of fp8, for example, no longer blows up the filesize.

---

### Details (4 commits)

1. **Stream checkpoint loads instead of materializing the whole file in RAM.** The converter loaded the entire source checkpoint into memory before doing anything with it. A new `LazyStateDict` reads each tensor from disk only when it's actually needed, so only the tensor currently being processed is ever resident. This also fixes "Checkpoint" mode loading an entire AIO file (model + text encoder + VAE) just to keep the model portion and discard the rest.

2. **Preserve native fp8 instead of upcasting to bf16 in keep-as-is branches.** Every "keep this layer as-is" branch (blacklisted layers, quantization-failure fallbacks, etc.) unconditionally upcast fp8 tensors to bf16. Upcasting fp8 to bf16 can't recover precision that's already gone, so for a checkpoint that ships natively in fp8, this only doubled the storage of every such tensor for no benefit.

3. **Defer scale-linked fp8 dequantization and periodically trim CPU memory.** A checkpoint whose fp8 layers are *properly scaled* (as opposed to bare native fp8) still needs genuine dequantization before re-quantizing. That combination was happening eagerly, for every such layer, in one pass over the whole file before the main conversion loop even started consuming them — reintroducing the same shape of memory problem the streaming loader was built to eliminate. This defers that combination to the moment each tensor is actually read, and adds a periodic call to reclaim memory that general-purpose memory allocators retain but don't return to the OS on their own.

4. **GPU memory hygiene.** A few small, independently-correct fixes: `torch.cuda.empty_cache()` added alongside the CPU-side trim; `@torch.no_grad()` on the conversion method, since this is pure weight transformation and never training; and a missing tensor cleanup in the main quantization branch that every other quantization branch already had.

None of the format-specific quantization math (fp8, int8, nvfp4, ConvRot, W4A8, etc.) needed to change — these branches only ever operate on whatever tensor they're handed, indifferent to how it arrived.

### Testing

Verified end to end against real checkpoints on real hardware (not just unit tests): real conversions of a 20GB AIO checkpoint and a 33GB diffusion model, to multiple target formats, with peak memory measured directly and results confirmed correct via ComfyUI's actual loading and inference path (not just "the conversion didn't crash").


Please lmk if you have any questions.

Best regards,
FNG